### PR TITLE
fixes js-yaml duplicated mapping key error & update languages.yml

### DIFF
--- a/data/languages.yml
+++ b/data/languages.yml
@@ -8,7 +8,8 @@
 #                     Use "text" if a mode does not exist.
 # wrap              - Boolean wrap to enable line wrapping (default: false)
 # extensions        - An Array of associated extensions (the first one is
-#                     considered the primary extension)
+#                     considered the primary extension, the others should be
+#                     listed alphabetically)
 # interpreters      - An Array of associated interpreters
 # searchable        - Boolean flag to enable searching (defaults to true)
 # search_term       - Deprecated: Some languages maybe indexed under a
@@ -18,6 +19,8 @@
 #                     language. This should match one of the scopes listed in
 #                     the grammars.yml file. Use "none" if there is no grammar
 #                     for this language.
+# group             - Name of the parent language. Languages in a group are counted
+#                     in the statistics as the parent language.
 #
 # Any additions or modifications (even trivial) should have corresponding
 # test change in `test/test_blob.rb`.
@@ -26,6 +29,7 @@
 
 ABAP:
   type: programming
+  color: "#E8274B"
   extensions:
   - .abap
   ace_mode: abap
@@ -41,6 +45,15 @@ AGS Script:
   tm_scope: source.c++
   ace_mode: c_cpp
 
+AMPL:
+  type: programming
+  color: "#E6EFBB"
+  extensions:
+  - .ampl
+  - .mod
+  tm_scope: source.ampl
+  ace_mode: text
+
 ANTLR:
   type: programming
   color: "#9DC3FF"
@@ -48,19 +61,28 @@ ANTLR:
   - .g4
   ace_mode: text
 
+API Blueprint:
+  type: markup
+  color: "#2ACCA8"
+  ace_mode: markdown
+  extensions:
+  - .apib
+  tm_scope: text.html.markdown.source.gfm.apib
+
 APL:
   type: programming
-  color: "#8a0707"
+  color: "#5A8164"
   extensions:
   - .apl
   - .dyalog
-  tm_scope: none
+  tm_scope: source.apl
   ace_mode: text
 
 ASP:
   type: programming
   color: "#6a40fd"
   search_term: aspx-vb
+  tm_scope: text.html.asp
   aliases:
   - aspx
   - aspx-vb
@@ -81,16 +103,15 @@ ATS:
   - ats2
   extensions:
   - .dats
-  - .atxt
   - .hats
   - .sats
-  tm_scope: source.ocaml
+  tm_scope: source.ats
   ace_mode: ocaml
 
 ActionScript:
   type: programming
   tm_scope: source.actionscript.3
-  color: "#e3491a"
+  color: "#882B0F"
   search_term: as3
   aliases:
   - actionscript 3
@@ -108,19 +129,20 @@ Ada:
   - .ada
   - .ads
   aliases:
-  - ada95ada2005
+  - ada95
+  - ada2005
   ace_mode: ada
 
 Agda:
   type: programming
-  color: "#467C91"
+  color: "#315665"
   extensions:
   - .agda
   ace_mode: text
 
 Alloy:
   type: programming  # 'modeling' would be more appropiate
-  color: "#cc5c24"
+  color: "#64C800"
   extensions:
   - .als
   ace_mode: text
@@ -140,7 +162,7 @@ ApacheConf:
   - apache
   extensions:
   - .apacheconf
-  - .conf
+  - .vhost
   tm_scope: source.apache-config
   ace_mode: apache_conf
 
@@ -161,10 +183,11 @@ AppleScript:
   interpreters:
   - osascript
   ace_mode: applescript
+  color: "#101F1F"
 
 Arc:
   type: programming
-  color: "#ca2afe"
+  color: "#aa2afe"
   extensions:
   - .arc
   tm_scope: none
@@ -186,27 +209,28 @@ AsciiDoc:
   - .asciidoc
   - .adoc
   - .asc
-  tm_scope: none
+  tm_scope: text.html.asciidoc
 
 AspectJ:
   type: programming
-  color: "#1957b0"
+  color: "#a957b0"
   extensions:
   - .aj
-  tm_scope: none
+  tm_scope: source.aspectj
   ace_mode: text
 
 Assembly:
   type: programming
-  color: "#a67219"
+  color: "#6E4C13"
   search_term: nasm
   aliases:
   - nasm
   extensions:
   - .asm
-  - .ASM
   - .a51
-  tm_scope: source.asm.x86
+  - .inc
+  - .nasm
+  tm_scope: source.assembly
   ace_mode: assembly_x86
 
 Augeas:
@@ -224,19 +248,19 @@ AutoHotkey:
   extensions:
   - .ahk
   - .ahkl
-  tm_scope: none
+  tm_scope: source.ahk
   ace_mode: autohotkey
 
 AutoIt:
   type: programming
-  color: "#36699B"
+  color: "#1C3552"
   aliases:
   - au3
   - AutoIt3
   - AutoItScript
   extensions:
   - .au3
-  tm_scope: source.autoit.3
+  tm_scope: none
   ace_mode: autohotkey
 
 Awk:
@@ -256,7 +280,6 @@ Awk:
 
 Batchfile:
   type: programming
-  group: Shell
   search_term: bat
   aliases:
   - bat
@@ -268,18 +291,22 @@ Batchfile:
   - .cmd
   tm_scope: source.dosbatch
   ace_mode: batchfile
+  color: "#C1F12E"
 
 Befunge:
+  type: programming
   extensions:
   - .befunge
   ace_mode: text
 
 Bison:
   type: programming
+  group: Yacc
   tm_scope: source.bison
   extensions:
-  - .y
+  - .bison
   ace_mode: text
+  color: "#6A463F"
 
 BitBake:
   type: programming
@@ -323,8 +350,11 @@ Boo:
   extensions:
   - .boo
   ace_mode: text
+  tm_scope: source.boo
 
 Brainfuck:
+  type: programming
+  color: "#2F2530"
   extensions:
   - .b
   - .bf
@@ -335,7 +365,7 @@ Brightscript:
   type: programming
   extensions:
   - .brs
-  tm_scope: none
+  tm_scope: source.brightscript
   ace_mode: text
 
 Bro:
@@ -346,15 +376,15 @@ Bro:
 
 C:
   type: programming
-  color: "#555"
+  color: "#555555"
   extensions:
   - .c
-  - .C
-  - .H
   - .cats
   - .h
   - .idc
   - .w
+  interpreters:
+  - tcc
   ace_mode: c_cpp
 
 C#:
@@ -367,6 +397,7 @@ C#:
   - csharp
   extensions:
   - .cs
+  - .cake
   - .cshtml
   - .csx
 
@@ -381,12 +412,14 @@ C++:
   - .cpp
   - .c++
   - .cc
+  - .cp
   - .cxx
   - .h
   - .h++
   - .hh
   - .hpp
   - .hxx
+  - .inc
   - .inl
   - .ipp
   - .tcc
@@ -417,9 +450,10 @@ CLIPS:
   ace_mode: text
 
 CMake:
+  type: programming
   extensions:
   - .cmake
-  - .in
+  - .cmake.in
   filenames:
   - CMakeLists.txt
   ace_mode: text
@@ -428,8 +462,6 @@ COBOL:
   type: programming
   extensions:
   - .cob
-  - .COB
-  - .CPY
   - .cbl
   - .ccp
   - .cobol
@@ -437,10 +469,19 @@ COBOL:
   ace_mode: cobol
 
 CSS:
+  type: markup
+  tm_scope: source.css
   ace_mode: css
   color: "#563d7c"
   extensions:
   - .css
+
+CSV:
+  type: data
+  ace_mode: text
+  tm_scope: none
+  extensions:
+  - .csv
 
 Cap'n Proto:
   type: programming
@@ -473,7 +514,15 @@ Chapel:
   - .chpl
   ace_mode: text
 
+Charity:
+  type: programming
+  extensions:
+    - .ch
+  tm_scope: none
+  ace_mode: text
+
 ChucK:
+  type: programming
   extensions:
   - .ck
   tm_scope: source.java
@@ -481,18 +530,34 @@ ChucK:
 
 Cirru:
   type: programming
-  color: "#aaaaff"
+  color: "#ccccff"
   ace_mode: cirru
   extensions:
   - .cirru
 
+Clarion:
+  type: programming
+  color: "#db901e"
+  ace_mode: text
+  extensions:
+  - .clw
+  tm_scope: source.clarion
+
 Clean:
   type: programming
-  color: "#3a81ad"
+  color: "#3F85AF"
   extensions:
   - .icl
   - .dcl
   tm_scope: none
+  ace_mode: text
+
+Click:
+  type: programming
+  color: "#E4E6F3"
+  extensions:
+  - .click
+  tm_scope: source.click
   ace_mode: text
 
 Clojure:
@@ -501,13 +566,14 @@ Clojure:
   color: "#db5855"
   extensions:
   - .clj
+  - .boot
   - .cl2
   - .cljc
   - .cljs
+  - .cljs.hl
   - .cljscm
   - .cljx
   - .hic
-  - .hl
   filenames:
   - riemann.config
 
@@ -522,6 +588,7 @@ CoffeeScript:
   extensions:
   - .coffee
   - ._coffee
+  - .cake
   - .cjsx
   - .cson
   - .iced
@@ -567,9 +634,11 @@ Common Lisp:
   - .lisp
   - .asd
   - .cl
+  - .l
   - .lsp
   - .ny
   - .podsl
+  - .sexp
   interpreters:
   - lisp
   - sbcl
@@ -580,7 +649,7 @@ Common Lisp:
 
 Component Pascal:
   type: programming
-  color: "#b0ce4e"
+  color: "#B0CE4E"
   extensions:
   - .cp
   - .cps
@@ -627,20 +696,23 @@ Creole:
 
 Crystal:
   type: programming
+  color: "#776791"
   extensions:
   - .cr
   ace_mode: ruby
-  tm_scope: source.ruby
+  tm_scope: source.crystal
   interpreters:
   - crystal
 
 Cucumber:
+  type: programming
   extensions:
   - .feature
   tm_scope: text.gherkin.feature
   aliases:
   - gherkin
   ace_mode: text
+  color: "#5B2063"
 
 Cuda:
   type: programming
@@ -649,6 +721,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
+  color: "#3A4E3A"
 
 Cycript:
   type: programming
@@ -670,7 +743,7 @@ Cython:
 
 D:
   type: programming
-  color: "#fcd46d"
+  color: "#ba595e"
   extensions:
   - .d
   - .di
@@ -683,17 +756,46 @@ D-ObjDump:
   tm_scope: objdump.x86asm
   ace_mode: assembly_x86
 
+DIGITAL Command Language:
+  type: programming
+  aliases:
+  - dcl
+  extensions:
+  - .com
+  tm_scope: none
+  ace_mode: text
+
 DM:
   type: programming
-  color: "#075ff1"
+  color: "#447265"
   extensions:
   - .dm
   aliases:
   - byond
-  tm_scope: source.c++
+  tm_scope: source.dm
+  ace_mode: c_cpp
+
+DNS Zone:
+  type: data
+  extensions:
+  - .zone
+  - .arpa
+  tm_scope: text.zone_file
+  ace_mode: text
+
+DTrace:
+  type: programming
+  aliases:
+  - dtrace-script
+  extensions:
+  - .d
+  interpreters:
+  - dtrace
+  tm_scope: source.c
   ace_mode: c_cpp
 
 Darcs Patch:
+  type: data
   search_term: dpatch
   aliases:
   - dpatch
@@ -705,17 +807,19 @@ Darcs Patch:
 
 Dart:
   type: programming
-  color: "#98BAD6"
+  color: "#00B4AB"
   extensions:
   - .dart
   ace_mode: dart
 
 Diff:
+  type: data
   extensions:
   - .diff
   - .patch
   aliases:
   - udiff
+  tm_scope: source.diff
   ace_mode: diff
 
 Dockerfile:
@@ -737,7 +841,7 @@ Dogescript:
 
 Dylan:
   type: programming
-  color: "#3ebc27"
+  color: "#6c616e"
   extensions:
   - .dylan
   - .dyl
@@ -762,9 +866,17 @@ ECL:
   tm_scope: none
   ace_mode: text
 
+ECLiPSe:
+  type: programming
+  group: prolog
+  extensions:
+  - .ecl
+  tm_scope: source.prolog.eclipse
+  ace_mode: prolog
+
 Eagle:
   type: markup
-  color: "#3994bc"
+  color: "#814C05"
   extensions:
   - .sch
   - .brd
@@ -793,6 +905,10 @@ Elixir:
   - .ex
   - .exs
   ace_mode: elixir
+  filenames:
+  - mix.lock
+  interpreters:
+  - elixir
 
 Elm:
   type: programming
@@ -811,14 +927,16 @@ Emacs Lisp:
   - emacs
   filenames:
   - .emacs
+  - .emacs.desktop
   extensions:
   - .el
   - .emacs
+  - .emacs.desktop
   ace_mode: lisp
 
 EmberScript:
   type: programming
-  color: "#f64e3e"
+  color: "#FFF4F3"
   extensions:
   - .em
   - .emberscript
@@ -827,12 +945,18 @@ EmberScript:
 
 Erlang:
   type: programming
-  color: "#0faf8d"
+  color: "#B83998"
   extensions:
   - .erl
   - .es
   - .escript
   - .hrl
+  - .xrl
+  - .yrl
+  filenames:
+  - rebar.config
+  - rebar.config.lock
+  - rebar.lock
   ace_mode: erlang
   interpreters:
   - escript
@@ -852,7 +976,7 @@ F#:
 
 FLUX:
   type: programming
-  color: "#33CCFF"
+  color: "#88ccff"
   extensions:
   - .fx
   - .flux
@@ -864,14 +988,6 @@ FORTRAN:
   color: "#4d41b1"
   extensions:
   - .f90
-  - .F
-  - .F03
-  - .F08
-  - .F77
-  - .F90
-  - .F95
-  - .FOR
-  - .FPP
   - .f
   - .f03
   - .f08
@@ -910,13 +1026,28 @@ Fantom:
   tm_scope: source.fan
   ace_mode: text
 
+Filterscript:
+  type: programming
+  group: RenderScript
+  extensions:
+  - .fs
+  tm_scope: none
+  ace_mode: text
+
+Formatted:
+  type: data
+  extensions:
+  - .for
+  - .eam.fs
+  tm_scope: none
+  ace_mode: text
+
 Forth:
   type: programming
   color: "#341708"
   extensions:
   - .fth
   - .4th
-  - .F
   - .f
   - .for
   - .forth
@@ -924,6 +1055,16 @@ Forth:
   - .frt
   - .fs
   ace_mode: forth
+
+FreeMarker:
+  type: programming
+  color: "#0050b2"
+  aliases:
+  - ftl
+  extensions:
+  - .ftl
+  tm_scope: text.html.ftl
+  ace_mode: ftl
 
 Frege:
   type: programming
@@ -939,7 +1080,7 @@ G-code:
   - .g
   - .gco
   - .gcode
-  tm_scope: none
+  tm_scope: source.gcode
   ace_mode: gcode
 
 GAMS:
@@ -956,7 +1097,8 @@ GAP:
   - .gap
   - .gd
   - .gi
-  tm_scope: none
+  - .tst
+  tm_scope: source.gap
   ace_mode: text
 
 GAS:
@@ -964,19 +1106,18 @@ GAS:
   group: Assembly
   extensions:
   - .s
-  - .S
-  tm_scope: source.asm.x86
+  - .ms
+  tm_scope: none
   ace_mode: assembly_x86
 
 GDScript:
   type: programming
   extensions:
   - .gd
-  tm_scope: none
+  tm_scope: source.gdscript
   ace_mode: text
 
 GLSL:
-  group: C
   type: programming
   extensions:
   - .glsl
@@ -984,6 +1125,7 @@ GLSL:
   - .frag
   - .frg
   - .fs
+  - .fsh
   - .fshader
   - .geo
   - .geom
@@ -992,18 +1134,20 @@ GLSL:
   - .shader
   - .vert
   - .vrx
+  - .vsh
   - .vshader
   ace_mode: glsl
 
 Game Maker Language:
   type: programming
-  color: "#8ad353"
+  color: "#8fb200"
   extensions:
   - .gml
   tm_scope: source.c++
   ace_mode: c_cpp
 
 Genshi:
+  type: programming
   extensions:
   - .kid
   tm_scope: text.xml.genshi
@@ -1013,6 +1157,7 @@ Genshi:
   ace_mode: xml
 
 Gentoo Ebuild:
+  type: programming
   group: Shell
   extensions:
   - .ebuild
@@ -1020,6 +1165,7 @@ Gentoo Ebuild:
   ace_mode: sh
 
 Gentoo Eclass:
+  type: programming
   group: Shell
   extensions:
   - .eclass
@@ -1027,6 +1173,7 @@ Gentoo Eclass:
   ace_mode: sh
 
 Gettext Catalog:
+  type: prose
   search_term: pot
   searchable: false
   aliases:
@@ -1067,10 +1214,10 @@ Go:
 
 Golo:
   type: programming
-  color: "#f6a51f"
+  color: "#88562A"
   extensions:
   - .golo
-  tm_scope: none
+  tm_scope: source.golo
   ace_mode: text
 
 Gosu:
@@ -1088,7 +1235,7 @@ Grace:
   type: programming
   extensions:
   - .grace
-  tm_scope: none
+  tm_scope: source.grace
   ace_mode: text
 
 Gradle:
@@ -1106,7 +1253,7 @@ Grammatical Framework:
   extensions:
   - .gf
   searchable: true
-  color: "#ff0000"
+  color: "#79aa7a"
   tm_scope: source.haskell
   ace_mode: haskell
 
@@ -1117,25 +1264,48 @@ Graph Modeling Language:
   tm_scope: none
   ace_mode: text
 
+GraphQL:
+  type: data
+  extensions:
+    - .graphql
+  color: "#E535AB"
+  tm_scope: source.graphql
+  ace_mode: text
+
 Graphviz (DOT):
   type: data
   tm_scope: source.dot
   extensions:
   - .dot
-  - .DOT
   - .gv
   ace_mode: text
 
 Groff:
+  type: markup
   extensions:
   - .man
   - '.1'
+  - .1in
+  - .1m
+  - .1x
   - '.2'
   - '.3'
+  - .3in
+  - .3m
+  - .3qt
+  - .3x
   - '.4'
   - '.5'
   - '.6'
   - '.7'
+  - '.8'
+  - '.9'
+  - .l
+  - .me
+  - .ms
+  - .n
+  - .rno
+  - .roff
   tm_scope: text.groff
   aliases:
   - nroff
@@ -1152,8 +1322,11 @@ Groovy:
   - .gvy
   interpreters:
   - groovy
+  filenames:
+  - Jenkinsfile
 
 Groovy Server Pages:
+  type: programming
   group: Groovy
   aliases:
   - gsp
@@ -1163,15 +1336,36 @@ Groovy Server Pages:
   tm_scope: text.html.jsp
   ace_mode: jsp
 
+HCL:
+  type: programming
+  extensions:
+    - .hcl
+    - .tf
+  ace_mode: ruby
+  tm_scope: source.ruby
+
+HLSL:
+  type: programming
+  extensions:
+    - .hlsl
+    - .fx
+    - .fxh
+    - .hlsli
+  ace_mode: text
+  tm_scope: none
+
 HTML:
   type: markup
   tm_scope: text.html.basic
   ace_mode: html
+  color: "#e44b23"
   aliases:
   - xhtml
   extensions:
   - .html
   - .htm
+  - .html.hl
+  - .inc
   - .st
   - .xht
   - .xhtml
@@ -1184,10 +1378,21 @@ HTML+Django:
   - .mustache
   - .jinja
   aliases:
+  - django
   - html+django/jinja
   - html+jinja
   - htmldjango
   ace_mode: django
+
+HTML+EEX:
+  type: markup
+  tm_scope: text.html.elixir
+  group: HTML
+  aliases:
+  - eex
+  extensions:
+  - .eex
+  ace_mode: text
 
 HTML+ERB:
   type: markup
@@ -1197,8 +1402,8 @@ HTML+ERB:
   - erb
   extensions:
   - .erb
-  - .deface
-  ace_mode: html_ruby
+  - .erb.deface
+  ace_mode: text
 
 HTML+PHP:
   type: markup
@@ -1222,19 +1427,24 @@ Hack:
   - .hh
   - .php
   tm_scope: text.html.php
+  color: "#878787"
 
 Haml:
   group: HTML
   type: markup
   extensions:
   - .haml
-  - .deface
+  - .haml.deface
   ace_mode: haml
+  color: "#ECE2A9"
 
 Handlebars:
   type: markup
+  color: "#01a9d6"
+  group: HTML
   aliases:
   - hbs
+  - htmlbars
   extensions:
   - .handlebars
   - .hbs
@@ -1246,7 +1456,7 @@ Harbour:
   color: "#0e60e3"
   extensions:
   - .hb
-  tm_scope: none
+  tm_scope: source.harbour
   ace_mode: text
 
 Haskell:
@@ -1260,7 +1470,7 @@ Haskell:
 Haxe:
   type: programming
   ace_mode: haxe
-  color: "#f7941e"
+  color: "#df7900"
   extensions:
   - .hx
   - .hxsl
@@ -1269,16 +1479,23 @@ Haxe:
 Hy:
   type: programming
   ace_mode: text
-  color: "#7891b1"
+  color: "#7790B2"
   extensions:
   - .hy
   aliases:
   - hylang
   tm_scope: source.hy
 
+HyPhy:
+  type: programming
+  ace_mode: text
+  extensions:
+  - .bf
+  tm_scope: none
+
 IDL:
   type: programming
-  color: "#e3592c"
+  color: "#a3522f"
   extensions:
   - .pro
   - .dlm
@@ -1300,6 +1517,7 @@ INI:
   - .ini
   - .cfg
   - .prefs
+  - .pro
   - .properties
   tm_scope: source.ini
   aliases:
@@ -1307,6 +1525,7 @@ INI:
   ace_mode: ini
 
 IRC log:
+  type: data
   search_term: irc
   aliases:
   - irc
@@ -1323,6 +1542,7 @@ Idris:
   - .idr
   - .lidr
   ace_mode: text
+  tm_scope: source.idris
 
 Inform 7:
   type: programming
@@ -1330,13 +1550,14 @@ Inform 7:
   extensions:
   - .ni
   - .i7x
-  tm_scope: source.Inform7
+  tm_scope: source.inform7
   aliases:
   - i7
   - inform7
   ace_mode: text
 
 Inno Setup:
+  type: programming
   extensions:
   - .iss
   tm_scope: none
@@ -1360,17 +1581,36 @@ Ioke:
 
 Isabelle:
   type: programming
-  color: "#fdcd00"
+  color: "#FEFE00"
   extensions:
   - .thy
   tm_scope: source.isabelle.theory
   ace_mode: text
 
+Isabelle ROOT:
+  type: programming
+  group: Isabelle
+  filenames:
+  - ROOT
+  tm_scope: source.isabelle.root
+  ace_mode: text
+
 J:
   type: programming
+  color: "#9EEDFF"
   extensions:
   - .ijs
-  tm_scope: none
+  tm_scope: source.j
+  ace_mode: text
+
+JFlex:
+  type: programming
+  color: "#DBCA00"
+  group: Lex
+  extensions:
+  - .flex
+  - .jflex
+  tm_scope: source.jflex
   ace_mode: text
 
 JSON:
@@ -1381,10 +1621,13 @@ JSON:
   searchable: false
   extensions:
   - .json
+  - .geojson
   - .lock
+  - .topojson
   filenames:
   - .jshintrc
   - composer.lock
+  - mcmod.info
 
 JSON5:
   type: data
@@ -1402,18 +1645,27 @@ JSONLD:
   tm_scope: source.js
 
 JSONiq:
+  color: "#40d47e"
   type: programming
   ace_mode: jsoniq
   extensions:
   - .jq
-  tm_scope: source.xquery
+  tm_scope: source.jq
+
+JSX:
+  type: programming
+  group: JavaScript
+  extensions:
+  - .jsx
+  tm_scope: source.js.jsx
+  ace_mode: javascript
 
 Jade:
   group: HTML
   type: markup
   extensions:
   - .jade
-  tm_scope: source.jade
+  tm_scope: text.jade
   ace_mode: jade
 
 Jasmin:
@@ -1431,6 +1683,7 @@ Java:
   - .java
 
 Java Server Pages:
+  type: programming
   group: Java
   search_term: jsp
   aliases:
@@ -1452,15 +1705,16 @@ JavaScript:
   - .js
   - ._js
   - .bones
+  - .es
   - .es6
   - .frag
   - .gs
   - .jake
   - .jsb
+  - .jscad
   - .jsfl
   - .jsm
   - .jss
-  - .jsx
   - .njs
   - .pac
   - .sjs
@@ -1492,11 +1746,32 @@ Julia:
   color: "#a270ba"
   ace_mode: julia
 
+Jupyter Notebook:
+  type: markup
+  ace_mode: json
+  tm_scope: source.json
+  color: "#DA5B0B"
+  extensions:
+  - .ipynb
+  filenames:
+  - Notebook
+  aliases:
+  - IPython Notebook
+
 KRL:
   type: programming
-  color: "#f5c800"
+  color: "#28431f"
   extensions:
   - .krl
+  tm_scope: none
+  ace_mode: text
+
+KiCad:
+  type: programming
+  extensions:
+  - .sch
+  - .brd
+  - .kicad_pcb
   tm_scope: none
   ace_mode: text
 
@@ -1509,6 +1784,7 @@ Kit:
 
 Kotlin:
   type: programming
+  color: "#F18E33"
   extensions:
   - .kt
   - .ktm
@@ -1526,9 +1802,11 @@ LFE:
   ace_mode: lisp
 
 LLVM:
+  type: programming
   extensions:
   - .ll
   ace_mode: text
+  color: "#185619"
 
 LOLCODE:
   type: programming
@@ -1543,6 +1821,7 @@ LSL:
   ace_mode: lsl
   extensions:
   - .lsl
+  - .lslp
   interpreters:
   - lsl
   color: '#3d9970'
@@ -1551,12 +1830,12 @@ LabVIEW:
   type: programming
   extensions:
   - .lvproj
-  tm_scope: none
-  ace_mode: text
+  tm_scope: text.xml
+  ace_mode: xml
 
 Lasso:
   type: programming
-  color: "#2584c3"
+  color: "#999999"
   extensions:
   - .lasso
   - .las
@@ -1574,8 +1853,15 @@ Latte:
   group: HTML
   extensions:
   - .latte
-  tm_scope: source.smarty
+  tm_scope: text.html.smarty
   ace_mode: smarty
+
+Lean:
+  type: programming
+  extensions:
+  - .lean
+  - .hlean
+  ace_mode: lean
 
 Less:
   type: markup
@@ -1584,18 +1870,56 @@ Less:
   - .less
   tm_scope: source.css.less
   ace_mode: less
+  color: "#A1D9A1"
+
+Lex:
+  type: programming
+  color: "#DBCA00"
+  aliases:
+  - flex
+  extensions:
+  - .l
+  - .lex
+  tm_scope: none
+  ace_mode: text
 
 LilyPond:
+  type: programming
   extensions:
   - .ly
   - .ily
+  ace_mode: text
+
+Limbo:
+  type: programming
+  extensions:
+  - .b
+  - .m
+  tm_scope: none
+  ace_mode: text
+
+Linker Script:
+  type: data
+  extensions:
+  - .ld
+  - .lds
+  filenames:
+  - ld.script
+  tm_scope: none
+  ace_mode: text
+
+Linux Kernel Module:
+  type: data
+  extensions:
+  - .mod
+  tm_scope: none
   ace_mode: text
 
 Liquid:
   type: markup
   extensions:
   - .liquid
-  tm_scope: none
+  tm_scope: text.html.liquid
   ace_mode: liquid
 
 Literate Agda:
@@ -1651,6 +1975,7 @@ Logos:
   - .x
   - .xi
   ace_mode: text
+  tm_scope: source.logos
 
 Logtalk:
   type: programming
@@ -1677,7 +2002,7 @@ LoomScript:
 Lua:
   type: programming
   ace_mode: lua
-  color: "#fa1fa1"
+  color: "#000080"
   extensions:
   - .lua
   - .fcgi
@@ -1698,32 +2023,78 @@ M:
   tm_scope: source.lisp
   ace_mode: lisp
 
+M4:
+  type: programming
+  extensions:
+  - .m4
+  tm_scope: none
+  ace_mode: text
+
+M4Sugar:
+  type: programming
+  group: M4
+  aliases:
+  - autoconf
+  extensions:
+  - .m4
+  filenames:
+  - configure.ac
+  tm_scope: none
+  ace_mode: text
+
+MAXScript:
+  type: programming
+  color: "#00a6a6"
+  extensions:
+  - .ms
+  - .mcr
+  tm_scope: source.maxscript
+  ace_mode: text
+
 MTML:
   type: markup
-  color: "#0095d9"
+  color: "#b7e1f4"
   extensions:
   - .mtml
   tm_scope: text.html.basic
   ace_mode: html
 
+MUF:
+  type: programming
+  group: Forth
+  extensions:
+  - .muf
+  - .m
+  tm_scope: none
+  ace_mode: forth
+
 Makefile:
   type: programming
+  color: "#427819"
   aliases:
   - bsdmake
   - make
   - mf
   extensions:
   - .mak
+  - .d
   - .mk
+  - .mkfile
   filenames:
   - GNUmakefile
+  - Kbuild
   - Makefile
+  - Makefile.am
+  - Makefile.in
+  - Makefile.inc
   - makefile
+  - mkfile
   interpreters:
   - make
   ace_mode: makefile
 
 Mako:
+  type: programming
   extensions:
   - .mako
   - .mao
@@ -1742,6 +2113,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
+  color: "#083FA1"
 
 Mask:
   type: markup
@@ -1758,8 +2130,11 @@ Mathematica:
   - .cdf
   - .m
   - .ma
+  - .mt
   - .nb
   - .nbp
+  - .wl
+  - .wlt
   aliases:
   - mma
   ace_mode: text
@@ -1767,6 +2142,8 @@ Mathematica:
 Matlab:
   type: programming
   color: "#bb92ac"
+  aliases:
+  - octave
   extensions:
   - .matlab
   - .m
@@ -1781,7 +2158,7 @@ Maven POM:
 
 Max:
   type: programming
-  color: "#ce279c"
+  color: "#c4a79c"
   aliases:
   - max/msp
   - maxmsp
@@ -1800,12 +2177,13 @@ MediaWiki:
   wrap: true
   extensions:
   - .mediawiki
-  tm_scope: none
+  - .wiki
+  tm_scope: text.html.mediawiki
   ace_mode: text
 
 Mercury:
   type: programming
-  color: "#abcdef"
+  color: "#ff2b2b"
   ace_mode: prolog
   interpreters:
   - mmi
@@ -1815,7 +2193,16 @@ Mercury:
   tm_scope: source.mercury
   ace_mode: prolog
 
+Metal:
+  type: programming
+  color: "#8f14e9"
+  extensions:
+  - .metal
+  tm_scope: source.c++
+  ace_mode: c_cpp
+
 MiniD: # Legacy
+  type: programming
   searchable: false
   extensions:
   - .minid # Dummy extension
@@ -1834,11 +2221,37 @@ Mirah:
   tm_scope: source.ruby
   ace_mode: ruby
 
+Modelica:
+  type: programming
+  extensions:
+  - .mo
+  tm_scope: source.modelica
+  ace_mode: text
+
+Modula-2:
+  type: programming
+  extensions:
+  - .mod
+  tm_scope: source.modula2
+  ace_mode: text
+
+Module Management System:
+  type: programming
+  extensions:
+  - .mms
+  - .mmk
+  filenames:
+  - descrip.mmk
+  - descrip.mms
+  tm_scope: none
+  ace_mode: text
+
 Monkey:
   type: programming
   extensions:
   - .monkey
   ace_mode: text
+  tm_scope: source.monkey
 
 Moocode:
   type: programming
@@ -1856,12 +2269,29 @@ MoonScript:
   ace_mode: text
 
 Myghty:
+  type: programming
   extensions:
   - .myt
   tm_scope: none
   ace_mode: text
 
+NCL:
+  type: programming
+  color: "#28431f"
+  extensions:
+  - .ncl
+  tm_scope: source.ncl
+  ace_mode: text
+
+NL:
+  type: data
+  extensions:
+  - .nl
+  tm_scope: none
+  ace_mode: text
+
 NSIS:
+  type: programming
   extensions:
   - .nsi
   - .nsh
@@ -1869,16 +2299,47 @@ NSIS:
 
 Nemerle:
   type: programming
-  color: "#0d3c6e"
+  color: "#3d3c6e"
   extensions:
   - .n
   ace_mode: text
 
+NetLinx:
+  type: programming
+  color: "#0aa0ff"
+  extensions:
+  - .axs
+  - .axi
+  tm_scope: source.netlinx
+  ace_mode: text
+
+NetLinx+ERB:
+  type: programming
+  color: "#747faa"
+  extensions:
+  - .axs.erb
+  - .axi.erb
+  tm_scope: source.netlinx.erb
+  ace_mode: text
+
 NetLogo:
   type: programming
-  color: "#ff2b2b"
+  color: "#ff6375"
   extensions:
   - .nlogo
+  tm_scope: source.lisp
+  ace_mode: lisp
+
+NewLisp:
+  type: programming
+  lexer: NewLisp
+  color: "#87AED7"
+  extensions:
+  - .nl
+  - .lisp
+  - .lsp
+  interpreters:
+  - newlisp
   tm_scope: source.lisp
   ace_mode: lisp
 
@@ -1886,10 +2347,14 @@ Nginx:
   type: markup
   extensions:
   - .nginxconf
+  - .vhost
+  filenames:
+  - nginx.conf
   tm_scope: source.nginx
   aliases:
   - nginx configuration file
   ace_mode: text
+  color: "#9469E9"
 
 Nimrod:
   type: programming
@@ -1909,7 +2374,7 @@ Ninja:
 
 Nit:
   type: programming
-  color: "#0d8921"
+  color: "#009917"
   extensions:
   - .nit
   tm_scope: source.nit
@@ -1917,7 +2382,7 @@ Nit:
 
 Nix:
   type: programming
-  color: "#7070ff"
+  color: "#7e7eff"
   extensions:
   - .nix
   aliases:
@@ -1940,6 +2405,7 @@ Nu:
   - nush
 
 NumPy:
+  type: programming
   group: Python
   extensions:
   - .numpy
@@ -1947,6 +2413,7 @@ NumPy:
   - .numsc
   tm_scope: none
   ace_mode: text
+  color: "#9C8AF9"
 
 OCaml:
   type: programming
@@ -1960,6 +2427,10 @@ OCaml:
   - .mli
   - .mll
   - .mly
+  interpreters:
+  - ocaml
+  - ocamlrun
+  tm_scope: source.ocaml
 
 ObjDump:
   type: data
@@ -1984,7 +2455,7 @@ Objective-C:
 Objective-C++:
   type: programming
   tm_scope: source.objc++
-  color: "#4886FC"
+  color: "#6866fb"
   aliases:
   - obj-c++
   - objc++
@@ -2025,7 +2496,7 @@ Opal:
   color: "#f7ede0"
   extensions:
   - .opal
-  tm_scope: none
+  tm_scope: source.opal
   ace_mode: text
 
 OpenCL:
@@ -2054,7 +2525,7 @@ OpenSCAD:
   extensions:
   - .scad
   tm_scope: none
-  ace_mode: text
+  ace_mode: scad
 
 Org:
   type: prose
@@ -2070,12 +2541,12 @@ Ox:
   - .ox
   - .oxh
   - .oxo
-  tm_scope: none
+  tm_scope: source.ox
   ace_mode: text
 
 Oxygene:
   type: programming
-  color: "#5a63a3"
+  color: "#cdd0e3"
   extensions:
   - .oxygene
   tm_scope: none
@@ -2083,7 +2554,7 @@ Oxygene:
 
 Oz:
   type: programming
-  color: "#fcaf3e"
+  color: "#fab738"
   extensions:
   - .oz
   tm_scope: source.oz
@@ -2094,8 +2565,9 @@ PAWN:
   color: "#dbb284"
   extensions:
   - .pwn
-  tm_scope: source.c++
-  ace_mode: c_cpp
+  - .inc
+  tm_scope: source.pawn
+  ace_mode: text
 
 PHP:
   type: programming
@@ -2107,9 +2579,11 @@ PHP:
   - .aw
   - .ctp
   - .fcgi
+  - .inc
   - .php3
   - .php4
   - .php5
+  - .phps
   - .phpt
   filenames:
   - Phakefile
@@ -2117,6 +2591,39 @@ PHP:
   - php
   aliases:
   - inc
+
+#Oracle
+PLSQL:
+  type: programming
+  ace_mode: sql
+  tm_scope: none
+  color: "#dad8d8"
+  extensions:
+  - .pls
+  - .pck
+  - .pkb
+  - .pks
+  - .plb
+  - .plsql
+  - .sql
+
+#Postgres
+PLpgSQL:
+  type: programming
+  ace_mode: pgsql
+  tm_scope: source.sql
+  extensions:
+  - .sql
+
+POV-Ray SDL:
+  type: programming
+  aliases:
+  - pov-ray
+  - povray
+  extensions:
+  - .pov
+  - .inc
+  ace_mode: text
 
 Pan:
   type: programming
@@ -2131,7 +2638,7 @@ Papyrus:
   color: "#6600cc"
   extensions:
   - .psc
-  tm_scope: none
+  tm_scope: source.papyrus.skyrim
   ace_mode: text
 
 Parrot:
@@ -2168,22 +2675,24 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#b0ce4e"
+  color: "#E3F171"
   extensions:
   - .pas
   - .dfm
   - .dpr
+  - .inc
   - .lpr
   - .pp
   ace_mode: pascal
 
 Perl:
   type: programming
+  tm_scope: source.perl
   ace_mode: perl
   color: "#0298c3"
   extensions:
   - .pl
-  - .PL
+  - .al
   - .cgi
   - .fcgi
   - .perl
@@ -2198,7 +2707,7 @@ Perl:
 
 Perl6:
   type: programming
-  color: "#0298c3"
+  color: "#0000fb"
   extensions:
   - .6pl
   - .6pm
@@ -2211,25 +2720,46 @@ Perl6:
   - .pm
   - .pm6
   - .t
+  filenames:
+  - Rexfile
   interpreters:
   - perl6
-  tm_scope: none
+  tm_scope: source.perl6fe
   ace_mode: perl
+
+Pickle:
+  type: data
+  extensions:
+  - .pkl
+  tm_scope: none
+  ace_mode: text
+
+PicoLisp:
+  type: programming
+  extensions:
+  - .l
+  interpreters:
+  - picolisp
+  - pil
+  tm_scope: source.lisp
+  ace_mode: lisp
 
 PigLatin:
   type: programming
   color: "#fcd7de"
   extensions:
   - .pig
-  tm_scope: none
+  tm_scope: source.pig_latin
   ace_mode: text
 
 Pike:
   type: programming
-  color: "#066ab2"
+  color: "#005390"
   extensions:
   - .pike
   - .pmod
+  interpreters:
+  - pike
   ace_mode: text
 
 Pod:
@@ -2245,7 +2775,14 @@ PogoScript:
   color: "#d80074"
   extensions:
   - .pogo
-  tm_scope: none
+  tm_scope: source.pogoscript
+  ace_mode: text
+
+Pony:
+  type: programming
+  extensions:
+  - .pony
+  tm_scope: source.pony
   ace_mode: text
 
 PostScript:
@@ -2270,7 +2807,7 @@ PowerShell:
 
 Processing:
   type: programming
-  color: "#2779ab"
+  color: "#0096D8"
   extensions:
   - .pde
   ace_mode: text
@@ -2280,19 +2817,21 @@ Prolog:
   color: "#74283c"
   extensions:
   - .pl
-  - .ecl
   - .pro
   - .prolog
+  - .yap
   interpreters:
   - swipl
+  - yap
+  tm_scope: source.prolog
   ace_mode: prolog
 
 Propeller Spin:
   type: programming
-  color: "#2b446d"
+  color: "#7fa2a7"
   extensions:
   - .spin
-  tm_scope: none
+  tm_scope: source.spin
   ace_mode: text
 
 Protocol Buffer:
@@ -2315,12 +2854,13 @@ Public Key:
 
 Puppet:
   type: programming
-  color: "#cc5555"
+  color: "#302B6D"
   extensions:
   - .pp
   filenames:
   - Modulefile
   ace_mode: text
+  tm_scope: source.puppet
 
 Pure Data:
   type: programming
@@ -2341,18 +2881,19 @@ PureBasic:
 
 PureScript:
   type: programming
-  color: "#bcdc53"
+  color: "#1D222D"
   extensions:
   - .purs
-  tm_scope: source.haskell
+  tm_scope: source.purescript
   ace_mode: haskell
 
 Python:
   type: programming
   ace_mode: python
-  color: "#3581ba"
+  color: "#3572A5"
   extensions:
   - .py
+  - .bzl
   - .cgi
   - .fcgi
   - .gyp
@@ -2361,10 +2902,12 @@ Python:
   - .pyp
   - .pyt
   - .pyw
+  - .rpy
   - .tac
   - .wsgi
   - .xpy
   filenames:
+  - BUCK
   - BUILD
   - SConscript
   - SConstruct
@@ -2374,6 +2917,8 @@ Python:
   - python
   - python2
   - python3
+  aliases:
+  - rusthon
 
 Python traceback:
   type: data
@@ -2385,14 +2930,16 @@ Python traceback:
   ace_mode: text
 
 QML:
-  type: markup
+  type: programming
   color: "#44a51c"
   extensions:
   - .qml
+  - .qbs
   tm_scope: source.qml
   ace_mode: text
 
 QMake:
+  type: programming
   extensions:
   - .pro
   - .pri
@@ -2402,15 +2949,13 @@ QMake:
 
 R:
   type: programming
-  color: "#198ce7"
+  color: "#198CE7"
   aliases:
   - R
   - Rscript
   - splus
   extensions:
   - .r
-  - .R
-  - .Rd
   - .rd
   - .rsx
   filenames:
@@ -2420,8 +2965,7 @@ R:
   ace_mode: r
 
 RAML:
-  type: data
-  lexer: YAML
+  type: markup
   ace_mode: yaml
   tm_scope: source.yaml
   color: "#77d9fb"
@@ -2435,6 +2979,7 @@ RDoc:
   extensions:
   - .rdoc
   tm_scope: text.rdoc
+  color: "#8E84BF"
 
 REALbasic:
   type: programming
@@ -2464,23 +3009,24 @@ RMarkdown:
   ace_mode: markdown
   extensions:
   - .rmd
-  - .Rmd
-  tm_scope: none
+  tm_scope: source.gfm
 
 Racket:
   type: programming
-  color: "#ae17ff"
+  color: "#22228f"
   extensions:
   - .rkt
   - .rktd
   - .rktl
   - .scrbl
+  interpreters:
+  - racket
   tm_scope: source.racket
   ace_mode: lisp
 
 Ragel in Ruby Host:
   type: programming
-  color: "#ff9c2e"
+  color: "#9d5200"
   extensions:
   - .rl
   aliases:
@@ -2490,6 +3036,7 @@ Ragel in Ruby Host:
   ace_mode: text
 
 Raw token data:
+  type: data
   search_term: raw
   aliases:
   - raw
@@ -2508,6 +3055,7 @@ Rebol:
   - .r3
   - .rebol
   ace_mode: text
+  tm_scope: source.rebol
 
 Red:
   type: programming
@@ -2517,12 +3065,31 @@ Red:
   - .reds
   aliases:
   - red/system
-  tm_scope: none
+  tm_scope: source.red
   ace_mode: text
 
 Redcode:
+  type: programming
   extensions:
   - .cw
+  tm_scope: none
+  ace_mode: text
+
+Ren'Py:
+  type: programming
+  aliases:
+  - renpy
+  color: "#ff7f7f"
+  extensions:
+  - .rpy
+  tm_scope: source.renpy
+  ace_mode: python
+
+RenderScript:
+  type: programming
+  extensions:
+  - .rs
+  - .rsh
   tm_scope: none
   ace_mode: text
 
@@ -2559,6 +3126,7 @@ Ruby:
   - .gemspec
   - .god
   - .irbrc
+  - .jbuilder
   - .mspec
   - .pluginspec
   - .podspec
@@ -2568,17 +3136,23 @@ Ruby:
   - .rbw
   - .rbx
   - .ru
+  - .ruby
   - .thor
   - .watchr
   interpreters:
   - ruby
   - macruby
   - rake
+  - jruby
+  - rbx
   filenames:
   - .pryrc
   - Appraisals
   - Berksfile
+  - Brewfile
   - Buildfile
+  - Deliverfile
+  - Fastfile
   - Gemfile
   - Gemfile.lock
   - Guardfile
@@ -2586,6 +3160,7 @@ Ruby:
   - Mavenfile
   - Podfile
   - Puppetfile
+  - Snapfile
   - Thorfile
   - Vagrantfile
   - buildfile
@@ -2595,11 +3170,12 @@ Rust:
   color: "#dea584"
   extensions:
   - .rs
+  - .rs.in
   ace_mode: rust
 
 SAS:
   type: programming
-  color: "#1E90FF"
+  color: "#B34936"
   extensions:
   - .sas
   tm_scope: source.sas
@@ -2612,10 +3188,38 @@ SCSS:
   ace_mode: scss
   extensions:
   - .scss
+  color: "#CF649A"
+
+SMT:
+  type: programming
+  extensions:
+  - .smt2
+  - .smt
+  interpreters:
+  - boolector
+  - cvc4
+  - mathsat5
+  - opensmt
+  - smtinterpol
+  - smt-rat
+  - stp
+  - verit
+  - yices2
+  - z3
+  tm_scope: source.smt
+  ace_mode: text
+
+SPARQL:
+  type: data
+  tm_scope: source.sparql
+  ace_mode: text
+  extensions:
+  - .sparql
+  - .rq
 
 SQF:
   type: programming
-  color: "#FFCB1F"
+  color: "#3F3F3F"
   extensions:
   - .sqf
   - .hqf
@@ -2630,30 +3234,48 @@ SQL:
   - .sql
   - .cql
   - .ddl
+  - .inc
   - .prc
   - .tab
   - .udf
   - .viw
+
+#IBM DB2
+SQLPL:
+  type: programming
+  ace_mode: sql
+  tm_scope: source.sql
+  extensions:
+  - .sql
+  - .db2
 
 STON:
   type: data
   group: Smalltalk
   extensions:
   - .ston
-  tm_scope: source.json
-  ace_mode: lisp
+  tm_scope: source.smalltalk
+  ace_mode: text
+
+SVG:
+  type: data
+  extensions:
+  - .svg
+  tm_scope: text.xml
+  ace_mode: xml
 
 Sage:
   type: programming
   group: Python
   extensions:
   - .sage
+  - .sagews
   tm_scope: source.python
   ace_mode: python
 
 SaltStack:
-  type: data
-  group: YAML
+  type: programming
+  color: "#646464"
   aliases:
   - saltstate
   - salt
@@ -2669,11 +3291,12 @@ Sass:
   extensions:
   - .sass
   ace_mode: sass
+  color: "#CF649A"
 
 Scala:
   type: programming
   ace_mode: scala
-  color: "#7dd3b0"
+  color: "#DC322F"
   extensions:
   - .scala
   - .sbt
@@ -2700,7 +3323,6 @@ Scheme:
   - .ss
   interpreters:
   - guile
-  - racket
   - bigloo
   - chicken
   ace_mode: scheme
@@ -2727,6 +3349,7 @@ Shell:
   color: "#89e051"
   aliases:
   - sh
+  - shell-script
   - bash
   - zsh
   extensions:
@@ -2737,8 +3360,17 @@ Shell:
   - .command
   - .fcgi
   - .ksh
+  - .sh.in
   - .tmux
+  - .tool
   - .zsh
+  filenames:
+  - .bash_history
+  - .bash_logout
+  - .bash_profile
+  - .bashrc
+  - PKGBUILD
+  - gradlew
   interpreters:
   - bash
   - rc
@@ -2775,10 +3407,18 @@ Slash:
 Slim:
   group: HTML
   type: markup
-  color: "#ff8877"
+  color: "#ff8f77"
   extensions:
   - .slim
+  tm_scope: text.slim
   ace_mode: text
+
+Smali:
+  type: programming
+  extensions:
+  - .smali
+  ace_mode: text
+  tm_scope: source.smali
 
 Smalltalk:
   type: programming
@@ -2791,26 +3431,39 @@ Smalltalk:
   ace_mode: text
 
 Smarty:
+  type: programming
   extensions:
   - .tpl
   ace_mode: smarty
+  tm_scope: text.html.smarty
 
 SourcePawn:
   type: programming
-  color: "#f69e1d"
+  color: "#5c7611"
   aliases:
   - sourcemod
   extensions:
   - .sp
+  - .inc
+  - .sma
   tm_scope: source.sp
   ace_mode: text
 
 Squirrel:
   type: programming
+  color: "#800000"
   extensions:
   - .nut
   tm_scope: source.c++
   ace_mode: c_cpp
+
+Stan:
+  type: programming
+  color: "#b2011d"
+  extensions:
+  - .stan
+  ace_mode: text
+  tm_scope: source.stan
 
 Standard ML:
   type: programming
@@ -2842,16 +3495,19 @@ Stylus:
   group: CSS
   extensions:
   - .styl
-  tm_scope: none
+  tm_scope: source.stylus
   ace_mode: stylus
 
 SuperCollider:
   type: programming
   color: "#46390b"
   extensions:
-  - .scd
   - .sc
-  tm_scope: none
+  - .scd
+  interpreters:
+  - sclang
+  - scsynth
+  tm_scope: source.supercollider
   ace_mode: text
 
 Swift:
@@ -2863,7 +3519,7 @@ Swift:
 
 SystemVerilog:
   type: programming
-  color: "#343761"
+  color: "#DAE1C2"
   extensions:
   - .sv
   - .svh
@@ -2881,7 +3537,7 @@ TXL:
   type: programming
   extensions:
   - .txl
-  tm_scope: none
+  tm_scope: source.txl
   ace_mode: text
 
 Tcl:
@@ -2936,12 +3592,38 @@ Tea:
   tm_scope: source.tea
   ace_mode: text
 
+Terra:
+  type: programming
+  extensions:
+  - .t
+  color: "#00004c"
+  ace_mode: lua
+  group: Lua
+  interpreters:
+  - lua
+
 Text:
   type: prose
   wrap: true
+  aliases:
+  - fundamental
   extensions:
   - .txt
   - .fr
+  - .nb
+  - .ncl
+  - .no
+  filenames:
+  - COPYING
+  - INSTALL
+  - LICENSE
+  - NEWS
+  - README.me
+  - click.me
+  - delete.me
+  - keep.me
+  - read.me
+  - test.me
   tm_scope: none
   ace_mode: text
 
@@ -2969,9 +3651,16 @@ Turing:
   tm_scope: none
   ace_mode: text
 
+Turtle:
+  type: data
+  extensions:
+  - .ttl
+  tm_scope: source.turtle
+  ace_mode: text
+
 Twig:
   type: markup
-  group: PHP
+  group: HTML
   extensions:
   - .twig
   tm_scope: text.html.twig
@@ -2979,11 +3668,12 @@ Twig:
 
 TypeScript:
   type: programming
-  color: "#31859c"
+  color: "#2b7489"
   aliases:
   - ts
   extensions:
   - .ts
+  - .tsx
   tm_scope: source.ts
   ace_mode: typescript
 
@@ -2991,10 +3681,29 @@ Unified Parallel C:
   type: programming
   group: C
   ace_mode: c_cpp
-  color: "#755223"
+  color: "#4e3617"
   extensions:
   - .upc
   tm_scope: source.c
+
+Unity3D Asset:
+  type: data
+  ace_mode: yaml
+  extensions:
+  - .anim
+  - .asset
+  - .mat
+  - .meta
+  - .prefab
+  - .unity
+  tm_scope: source.yaml
+
+Uno:
+  type: programming
+  extensions:
+  - .uno
+  ace_mode: csharp
+  tm_scope: source.cs
 
 UnrealScript:
   type: programming
@@ -3004,17 +3713,28 @@ UnrealScript:
   tm_scope: source.java
   ace_mode: java
 
-VCL:
+UrWeb:
   type: programming
-  ace_mode: perl
-  color: "#0298c3"
+  aliases:
+  - Ur/Web
+  - Ur
+  extensions:
+  - .ur
+  - .urs
+  tm_scope: source.ur
+  ace_mode: text
+
+VCL:
+  group: Perl
+  type: programming
   extensions:
   - .vcl
-  tm_scope: source.perl
+  tm_scope: source.varnish.vcl
+  ace_mode: text
 
 VHDL:
   type: programming
-  color: "#543978"
+  color: "#adb2cb"
   extensions:
   - .vhdl
   - .vhd
@@ -3028,7 +3748,7 @@ VHDL:
 
 Vala:
   type: programming
-  color: "#ee7d06"
+  color: "#fbe5cd"
   extensions:
   - .vala
   - .vapi
@@ -3036,7 +3756,7 @@ Vala:
 
 Verilog:
   type: programming
-  color: "#848bf3"
+  color: "#b2b7f8"
   extensions:
   - .v
   - .veo
@@ -3044,16 +3764,19 @@ Verilog:
 
 VimL:
   type: programming
-  color: "#199c4b"
+  color: "#199f4b"
   search_term: vim
   aliases:
   - vim
+  - nvim
   extensions:
   - .vim
   filenames:
+  - .nvimrc
   - .vimrc
   - _vimrc
   - gvimrc
+  - nvimrc
   - vimrc
   ace_mode: text
 
@@ -3077,11 +3800,27 @@ Visual Basic:
 
 Volt:
   type: programming
-  color: "#0098db"
+  color: "#1F1F1F"
   extensions:
   - .volt
   tm_scope: source.d
   ace_mode: d
+
+Vue:
+  type: markup
+  color: "#2c3e50"
+  extensions:
+  - .vue
+  tm_scope: text.html.vue
+  ace_mode: html
+
+Web Ontology Language:
+  type: markup
+  color: "#9cc9dd"
+  extensions:
+  - .owl
+  tm_scope: text.xml
+  ace_mode: xml
 
 WebIDL:
   type: programming
@@ -3090,15 +3829,26 @@ WebIDL:
   tm_scope: source.webidl
   ace_mode: text
 
+X10:
+  type: programming
+  aliases:
+  - xten
+  ace_mode: text
+  extensions:
+  - .x10
+  color: "#4B6BEF"
+  tm_scope: source.x10
+
 XC:
   type: programming
+  color: "#99DA07"
   extensions:
   - .xc
-  tm_scope: source.c
+  tm_scope: source.xc
   ace_mode: c_cpp
 
 XML:
-  type: markup
+  type: data
   ace_mode: xml
   aliases:
   - rss
@@ -3111,27 +3861,37 @@ XML:
   - .ccxml
   - .clixml
   - .cproject
+  - .csl
   - .csproj
   - .ct
   - .dita
   - .ditamap
   - .ditaval
   - .dll.config
+  - .dotsettings
   - .filters
   - .fsproj
+  - .fxml
   - .glade
+  - .gml
   - .grxml
+  - .iml
   - .ivy
   - .jelly
+  - .jsproj
   - .kml
   - .launch
+  - .mdpolicy
   - .mm
+  - .mod
   - .mxml
   - .nproj
   - .nuspec
+  - .odd
   - .osm
   - .plist
   - .pluginspec
+  - .props
   - .ps1xml
   - .psc1
   - .pt
@@ -3139,21 +3899,24 @@ XML:
   - .rss
   - .scxml
   - .srdf
+  - .storyboard
   - .stTheme
   - .sublime-snippet
-  - .svg
   - .targets
   - .tmCommand
+  - .tml
   - .tmLanguage
   - .tmPreferences
   - .tmSnippet
   - .tmTheme
-  - .tml
   - .ts
+  - .tsx
   - .ui
   - .urdf
+  - .ux
   - .vbproj
   - .vcxproj
+  - .vssettings
   - .vxml
   - .wsdl
   - .wsf
@@ -3163,21 +3926,33 @@ XML:
   - .x3d
   - .xacro
   - .xaml
+  - .xib
   - .xlf
   - .xliff
   - .xmi
   - .xml.dist
+  - .xproj
   - .xsd
   - .xul
   - .zcml
   filenames:
   - .classpath
   - .project
+  - App.config
+  - NuGet.config
   - Settings.StyleCop
   - Web.Debug.config
   - Web.Release.config
   - Web.config
   - packages.config
+
+XPages:
+  type: programming
+  extensions:
+  - .xsp-config
+  - .xsp.metadata
+  tm_scope: none
+  ace_mode: xml
 
 XProc:
   type: programming
@@ -3189,7 +3964,7 @@ XProc:
 
 XQuery:
   type: programming
-  color: "#2700e2"
+  color: "#5232e7"
   extensions:
   - .xquery
   - .xq
@@ -3197,8 +3972,10 @@ XQuery:
   - .xqm
   - .xqy
   ace_mode: xquery
+  tm_scope: source.xq
 
 XS:
+  type: programming
   extensions:
   - .xs
   tm_scope: source.c
@@ -3213,6 +3990,7 @@ XSLT:
   - .xsl
   tm_scope: text.xml.xsl
   ace_mode: xml
+  color: "#EB8CEB"
 
 Xojo:
   type: programming
@@ -3241,8 +4019,30 @@ YAML:
   - .yml
   - .reek
   - .rviz
+  - .sublime-syntax
+  - .syntax
   - .yaml
+  - .yaml-tmlanguage
+  filenames:
+  - .clang-format
   ace_mode: yaml
+
+YANG:
+  type: data
+  extensions:
+  - .yang
+  tm_scope: source.yang
+  ace_mode: text
+
+Yacc:
+  type: programming
+  extensions:
+  - .y
+  - .yacc
+  - .yy
+  tm_scope: source.bison
+  ace_mode: text
+  color: "#4B6C4B"
 
 Zephir:
   type: programming
@@ -3261,19 +4061,27 @@ Zimpl:
   tm_scope: none
   ace_mode: text
 
+desktop:
+  type: data
+  extensions:
+  - .desktop
+  - .desktop.in
+  tm_scope: source.desktop
+  ace_mode: text
+
 eC:
   type: programming
+  color: "#913960"
   search_term: ec
   extensions:
   - .ec
   - .eh
-  tm_scope: none
+  tm_scope: source.c.ec
   ace_mode: text
 
 edn:
   type: data
   ace_mode: clojure
-  color: "#db5855"
   extensions:
   - .edn
   tm_scope: source.clojure
@@ -3287,16 +4095,18 @@ fish:
   ace_mode: text
 
 mupad:
+  type: programming
   extensions:
   - .mu
   ace_mode: text
 
 nesC:
   type: programming
-  color: "#ffce3b"
+  color: "#94B0C7"
   extensions:
   - .nc
   ace_mode: text
+  tm_scope: source.nesc
 
 ooc:
   type: programming
@@ -3314,7 +4124,10 @@ reStructuredText:
   extensions:
   - .rst
   - .rest
+  - .rest.txt
+  - .rst.txt
   ace_mode: text
+  color: "#B3BCBC"
 
 wisp:
   type: programming
@@ -3326,8 +4139,15 @@ wisp:
 
 xBase:
   type: programming
-  color: "#3a4040"
+  color: "#403a40"
+  aliases:
+  - advpl
+  - clipper
+  - foxpro
   extensions:
   - .prg
-  tm_scope: none
+  - .ch
+  - .prw
+  tm_scope: source.harbour
   ace_mode: text
+  

--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -10,7 +10,7 @@ module.exports =
   #
   # Returns an {Object} mapping language name to language record.
   all: (recordsPath = path.join(__dirname, '../data/languages.yml')) ->
-    @languages ?= Yaml.safeLoad(fs.readFileSync(recordsPath))
+    @languages ?= Yaml.safeLoad(fs.readFileSync(recordsPath), {json: true})
 
   # Public: Finds the list of language candidates from the supplied extension.
   #


### PR DESCRIPTION
It seems js-yaml starts issuing error on duplicated mapping key since around js-yaml@3.5
nodeca/js-yaml#242
adding json option fixes by overriding duplicated mapping key as it was expected before.
- languages.yml update from https://github.com/github/linguist/commit/c3145d3c08f11048d8de5c755f9f3ad86056f01a
